### PR TITLE
existing project check and init default.

### DIFF
--- a/src/file/file.cpp
+++ b/src/file/file.cpp
@@ -19,7 +19,7 @@ using namespace std;
 #define CHUNK 16384
 
 string FileManager::cwd() {
-  char buffer[FILENAME_MAX];
+  char buffer[FILENAME_MAX] = {0};
   getcwd(buffer, FILENAME_MAX);
 
 
@@ -209,7 +209,7 @@ list<string> FileManager::dir_list(std::string path, std::string extension) {
         string name = filename.substr(0, filename.find_last_of("."));
         string ext  = filename.substr(filename.find_last_of(".") + 1);
 
-        if(ext == extension) {
+        if(extension == "" || ext == extension) {
           list.push_back(name);
         }
       }

--- a/src/file/file.h
+++ b/src/file/file.h
@@ -16,7 +16,7 @@ public:
   static bool is_dir(std::string path);
   static bool is_dot_dir(std::string path);
   static void delete_dir(std::string path);
-  static std::list<std::string> dir_list(std::string path, std::string extension);
+  static std::list<std::string> dir_list(std::string path, std::string extension = "");
   static bool unzip(std::string source, std::string destination);
 
 private:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,12 +132,13 @@ int main(int argc, char **argv) {
   if(nw != args.end()) {
 
     auto arg = args.find("<name>");
+
+    string name = ".";    
     if(arg != args.end() && arg->second) {
-      Project::init(arg->second.asString());
-    } else {
-      cout << "A project name is required" << endl;
+      name = arg->second.asString();
     }
 
+    Project::init(name);
     return EXIT_SUCCESS;
   }
 

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -19,9 +19,12 @@ void Project::init(string name, string tpl) {
 
   string project_name = directory.substr(directory.find_last_of("/"));
     
-  if(!FileManager::dir_exists(directory)) {
-    FileManager::create_path(0755, directory);
+  if(exists(directory)) {
+    console::error("Not an empty directory, we don't want to overwrite any current projects");
+    exit(EXIT_FAILURE);
   }
+
+  FileManager::create_path(0755, directory);
 
   TemplateDetails tpl_details = Template::find(tpl);
   if(tpl_details.repo.length() < 1) {
@@ -50,4 +53,16 @@ void Project::init(string name, string tpl) {
   config_template.setValue("name", proj);
 
   FileManager::write(template_path, config_template.render());
+}
+
+bool Project::exists(std::string directory) {
+  if(FileManager::dir_exists(directory)) {
+      list<string>files = FileManager::dir_list(directory);
+
+      if(files.size() > 0) {
+        return true;
+      }
+  }
+
+  return false;
 }

--- a/src/project/project.h
+++ b/src/project/project.h
@@ -7,6 +7,9 @@
 class Project {
 public:
   static void init(std::string name, std::string tpl = "base");
+
+private:
+  static bool exists(std::string directory);
 };
 
 #endif


### PR DESCRIPTION
- Does lightweight check for existing project, and bails if folder contains files
- Add ability to init in a folder without need to use "." as current directory, if no project name is provided, current directory is assumed.

---

https://www.pivotaltracker.com/story/show/153864107
[Deliviers #153864107]