### PR TITLE
Update ClI project config creation

### DIFF
--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -50,9 +50,13 @@ void Project::init(string name, string tpl) {
   string proj   = replace(project_name, "/", "");
   Json json     = Json::parse(Request::create_project(proj).body, err);
   string token  = json["token"].string_value();
+  string project_task_id = json["project_tasks"][0]["id"].string_value();
+  string project_task_name = json["project_tasks"][0]["name"].string_value();
 
   config_template.setValue("token", token);
   config_template.setValue("name", proj);
+  config_template.setValue("project_task_id", project_task_id);
+  config_template.setValue("project_task_name", project_task_name);
 
   FileManager::write(template_path, config_template.render());
 }

--- a/src/project_env/project_env.cpp
+++ b/src/project_env/project_env.cpp
@@ -77,5 +77,8 @@ ProjectDetails ProjectEnv::parse_project(string path) {
   
   }
 
+  details.token         = token;
+  details.project_tasks = prj_tasks; 
+
   return details;
 }

--- a/src/project_env/project_env.cpp
+++ b/src/project_env/project_env.cpp
@@ -47,9 +47,23 @@ ProjectDetails ProjectEnv::parse_project(string path) {
     exit(EXIT_FAILURE);
   }
 
-  const string token      = prj["project_token"].as<string>();
-  const string name       = prj["name"].as<string>();
-  const string entrypoint = prj["entrypoint"].as<string>();
+  if (prj["project_tasks"]){
+    console::debug("Using multi task (new) config file"); 
+
+    for (int j = 0; prj["project_tasks"][j] ; j++) {
+      name       = prj["project_tasks"][j]["name"].as<string>();
+      entrypoint = prj["project_tasks"][j]["entrypoint"].as<string>();
+      task_id    = prj["project_tasks"][j]["project_task_id"].as<string>();
+      
+      prj_task_info.name = name;
+      prj_task_info.entrypoint = entrypoint;
+      prj_task_info.task_id = task_id;
+      prj_tasks.push_back(prj_task_info);  
+    }
+
+    token = prj["project_token"].as<string>();
+    
+  } else {
 
   details.token       = token;
   details.name        = name;

--- a/src/project_env/project_env.cpp
+++ b/src/project_env/project_env.cpp
@@ -31,6 +31,12 @@ ProjectDetails ProjectEnv::_current() {
 
 ProjectDetails ProjectEnv::parse_project(string path) {
   ProjectDetails details;
+  ProjectTask prj_task_info;
+  std::vector<ProjectTask> prj_tasks;
+  std::string name = "";
+  std::string entrypoint = "";
+  std::string task_id = "";
+  std::string token = "";
 
   YAML::Node prj;
   

--- a/src/project_env/project_env.cpp
+++ b/src/project_env/project_env.cpp
@@ -64,10 +64,18 @@ ProjectDetails ProjectEnv::parse_project(string path) {
     token = prj["project_token"].as<string>();
     
   } else {
+    console::debug("Using single task (old) config file"); 
 
-  details.token       = token;
-  details.name        = name;
-  details.entrypoint  = entrypoint;
+    token      = prj["project_token"].as<string>();
+    name       = prj["name"].as<string>();
+    entrypoint = prj["entrypoint"].as<string>();
+
+    prj_task_info.name = name;
+    prj_task_info.entrypoint = entrypoint;
+    prj_task_info.task_id = task_id;
+    prj_tasks.push_back(prj_task_info);
+  
+  }
 
   return details;
 }

--- a/src/project_env/project_env.h
+++ b/src/project_env/project_env.h
@@ -5,10 +5,15 @@
 
 #define PROJECT_TOKEN  ProjectEnv::current().token
 
-struct ProjectDetails {
-  std::string token;
+struct ProjectTask {
+  std::string task_id;
   std::string name;
   std::string entrypoint;
+};
+
+struct ProjectDetails {
+  std::vector<ProjectTask> project_tasks;
+  std::string token;
 };
 
 class ProjectEnv {

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -8,12 +8,13 @@ using namespace json11;
 
 #define ENDPOINT(str) Url{(API_URL + str)}
 
-const string LOGIN_URL    = "/users/login";
-const string PING_URL     = "/ping";
-const string TOKEN_URL    = "/api_tokens/";
-const string PROJECT_URL  = "/projects";
-const string ENV_VARS_URL = "/env_vars";
-const string FETCH_URL    = "/data";
+const string LOGIN_URL          = "/users/login";
+const string PING_URL           = "/ping";
+const string TOKEN_URL          = "/api_tokens/";
+const string PROJECT_URL        = "/projects";
+const string ENV_VARS_URL       = "/env_vars";
+const string FETCH_URL          = "/data";
+const string PROJECT_TASKS_URL  = "/project_tasks";
 
 #define DEFAULT_HEADERS() \
 RestClient::HeaderFields headers = this->_default_headers(); \
@@ -159,6 +160,19 @@ RestClient::Response Request::_fetch(string project_id, string table) {
   return this->connection->get(uri);
 }
 
+RestClient::Response Request::_create_task(string name, string project_id) {
+  API_HEADERS();
+
+  Json body = Json::object {
+    {"name", name}
+  };
+
+  string uri = PROJECT_URL + "/" + project_id + "/" + PROJECT_TASKS_URL + "/";
+
+  return this->connection->post(uri, body.dump());
+}
+
+
 // DOWNLOAD 
 size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
@@ -240,6 +254,10 @@ RestClient::Response Request::delete_env_var(string project_id, string key) {
 
 RestClient::Response Request::fetch(string project_id, string table) {
   return instance()->_fetch(project_id, table);
+}
+
+RestClient::Response Request::create_task(string name, string project_id) {
+  return instance()->_create_task(name, project_id);
 }
 
 // DOWNLOAD

--- a/src/request/request.h
+++ b/src/request/request.h
@@ -18,6 +18,7 @@ public:
   static RestClient::Response add_env_var(std::string project_id, std::string key, std::string value);
   static RestClient::Response delete_env_var(std::string project_id, std::string key);
   static RestClient::Response fetch(std::string project_id, std::string table);
+  static RestClient::Response create_task(std::string name, std::string project_id);
 
   static void download(std::string url, std::string save_path);
 
@@ -42,6 +43,7 @@ private:
   RestClient::Response _add_env_var(std::string project_id, std::string key, std::string value);
   RestClient::Response _delete_env_var(std::string project_id, std::string key);
   RestClient::Response _fetch(std::string project_id, std::string table);
+  RestClient::Response _create_task(std::string name, std::string project_id);
 
   static void _download(std::string url, std::string save_path);
 };


### PR DESCRIPTION
## Overview 
In order to support multiple tasks, the config file needs to hold the information for all tasks. An initial task is created on project creation that must be added. 

## Story 
https://www.pivotaltracker.com/story/show/154486099
https://www.pivotaltracker.com/story/show/154876458

## Epic 
https://www.pivotaltracker.com/epic/show/3858897

## Changes
- add project_task info to config.yml file on project creation
- ability to parse old or new config file 
- updated ProjectDetails struct (added project tasks struct) 

## Other Repos 
- PR for template updates 