### PR TITLE
Cli kill messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 ## Usage:
-    skafos (setup|init|auth|version)...
-    skafos init <name>
+    skafos (setup|init|auth)...
+    skafos init [<name>] [--template <template_name>] [--master]
     skafos templates [--update] [--search <search_term>]
-    skafos logs <project_token> [-n <num>] [--tail]
+    skafos env [<key>] [--set <value>] [--delete]
+    skafos logs [<project_token>] [-n <num>] [--tail]
+    skafos fetch --table <table_name>
+    skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
     skafos -h | --help
-    skafos --version
+    skafos -v | --version
 ## Commands:
     setup       Setup development environment.
-    new         Create a new project
-    auth        Authenticate request.    
-    version     Shows version.
+    init        Create a new project.
+    auth        Authenticate request.
+    templates   Manage templates.
+    env         Get or set environment variables.
     logs        Get logs for a project.
+    fetch       Fetch results from a given table.
+    kill        Kill an entire project or specific jobs/deployments.
 ## Options:
     -V --version             Shows version.
 
@@ -20,3 +26,10 @@ If you need help, feel free to reach out:
 - https://metismachine.com
 - https://twitter.com/metismachine
 - https://github.com/metismachine
+
+Skafos is currently under a private beta but don't despair 
+because we are offering an opportunity for you to get early access. 
+
+Please go to https://metismachine.typeform.com/to/JzdHLh to make it so. 
+
+Fire it up!

--- a/src/project/project.h
+++ b/src/project/project.h
@@ -10,6 +10,7 @@ public:
   static void kill(std::string project_token);
   static void kill(std::string jobs, std::string deployments);
   static void kill(std::string project_token, std::string jobs, std::string deployments);
+  static void kill_message(json11::Json kill_json, std::string kill_type, std::string kill_details);
  
 private:
   static bool exists(std::string directory);

--- a/src/usage.h
+++ b/src/usage.h
@@ -10,7 +10,7 @@ Usage:
     skafos env [<key>] [--set <value>] [--delete]
     skafos logs [<project_token>] [-n <num>] [--tail]
     skafos fetch --table <table_name>
-    skafos kill [<project_token>] [--deployments <deployment_ids>] [--jobs <job_ids>]
+    skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
     skafos -h | --help
     skafos -v | --version
 Commands:

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef __CLI_VERSION__
 #define __CLI_VERSION__
 
-#define VERSION "1.2.1-dev"
+#define VERSION "1.3.0-dev"
 
 #endif
 


### PR DESCRIPTION
Currently, the kill messages for successes and failures refer to everything as deployments. This PR adjusts the messages to refer to jobs or deployments where appropriate. 

## Changes 
- create kill_message function from repeated code in three kill function 
- add the kill_message function as a separate function to apply to all three kill functions
- update the kill command flags to mach the available documentation 
- update readme with additional usage, commands, and comments about skafos status