### PR TITLE
CLI Log Lines Output

### DIFF
--- a/src/logs/logs.cpp
+++ b/src/logs/logs.cpp
@@ -3,6 +3,7 @@
 #include "http.h"
 #include "env/env.h"
 #include "common.h"
+#include <algorithm>
 
 using namespace json11;
 

--- a/src/logs/logs.cpp
+++ b/src/logs/logs.cpp
@@ -20,9 +20,8 @@ void sse_event(const char* data) {
 
   if (eventtype.compare("message") == 0 && json["data"].is_string()) {
     std::string message = json["data"].string_value();
-
+    message.erase(std::remove(message.begin(), message.end(), '\n'), message.end());
     console::info(message);
-    std::cout << std::endl;
   }
 }
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef __CLI_VERSION__
 #define __CLI_VERSION__
 
-#define VERSION "1.3.1-dev"
+#define VERSION "1.3.2-dev"
 
 #endif
 


### PR DESCRIPTION
The log command provides empty lines between logs and leaves trailing new lines in the messaged. There is a need to remove empty lines and escaped newlines from log output. 

## Changes 
- remove `\n`from messages 
- remove empty line between log messages 