### PR TITLE
remote info command - vasi base url 

### DIFF
--- a/build_envs/production_env.h
+++ b/build_envs/production_env.h
@@ -8,5 +8,6 @@ const std::string ENVIRONMENT = "production";
 const std::string CLIENT_ID   = "0cbe0e8754f1492cac415f73cea669bb";
 const std::string API_URL     = "https://api.metismachine.io/v1";
 const std::string LOGGING_URL = "https://api.metismachine.io/logs/";
+const std::string VASI_URL    = "https://vasi.metismachine.io/";
 
 #endif

--- a/build_envs/staging_env.h
+++ b/build_envs/staging_env.h
@@ -8,5 +8,6 @@ const std::string ENVIRONMENT = "staging";
 const std::string CLIENT_ID   = "f1f6e59f3f6f8ffecde29d34ad18f673";
 const std::string API_URL     = "https://api.metis.wtf/v1";
 const std::string LOGGING_URL = "http://argus.metis.wtf/logs/";
+const std::string VASI_URL    = "http://vasi.metis.wtf/";
 
 #endif

--- a/src/dispatch/dispatch.cpp
+++ b/src/dispatch/dispatch.cpp
@@ -286,9 +286,11 @@ void kill_deployment(int argc, char **argv, int cmd_index){
 }
 
 void remote(int argc, char **argv, int cmd_index){
-  string project_name = ProjectEnv::current().name != "" ? ProjectEnv::current().name : ProjectEnv::current().token;
+  string project_name;
   if(argc == 4) {
     project_name = string(argv[3]);
+  } else {
+    project_name = ProjectEnv::current().name != "" ? ProjectEnv::current().name : ProjectEnv::current().token;
   }
 
   Project::remote_add(project_name);

--- a/src/dispatch/dispatch.cpp
+++ b/src/dispatch/dispatch.cpp
@@ -286,14 +286,13 @@ void kill_deployment(int argc, char **argv, int cmd_index){
 }
 
 void remote(int argc, char **argv, int cmd_index){
-  string project_name;
-  if(argc == 4) {
-    project_name = string(argv[3]);
-  } else {
-    project_name = ProjectEnv::current().name != "" ? ProjectEnv::current().name : ProjectEnv::current().token;
-  }
+  string project_token = ".";
 
-  Project::remote_add(project_name);
+  if(argc == 4) {
+    project_token = string(argv[3]);
+  } 
+
+  Project::remote_add(project_token);
 }
 
 

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -67,7 +67,11 @@ void Project::init(string name, string tpl, bool master) {
   FileManager::write(template_path, config_template.render());
 }
 
-void Project::remote_add(string& project_name){
+void Project::remote_add(string project_token){
+  if(project_token.compare(".") == 0){
+    project_token = PROJECT_TOKEN;
+  }
+
   std::string selected_org;
   std::string err;
 
@@ -99,7 +103,7 @@ void Project::remote_add(string& project_name){
     selected_org = list[index]["id"].string_value();
   }
     console::info("To add a new remote, copy the git remote add skafos command below and run it on the terminal.");
-    console::info("$ git remote add skafos" + VASI_URL + selected_org + "/" + project_name);
+    console::info("$ git remote add skafos" + VASI_URL + selected_org + "/" + project_token);
     console::info("You can then push changes for deployment using the git push skafos <branch_name> command.");
 }
 

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -99,7 +99,7 @@ void Project::remote_add(string& project_name){
     selected_org = list[index]["id"].string_value();
   }
     console::info("To add a new remote, copy the git remote add skafos command below and run it on the terminal.");
-    console::info("$ git remote add skafos https://vasi.metismachine.io/" + selected_org + "/" + project_name);
+    console::info("$ git remote add skafos" + VASI_URL + selected_org + "/" + project_name);
     console::info("You can then push changes for deployment using the git push skafos <branch_name> command.");
 }
 

--- a/src/project/project.h
+++ b/src/project/project.h
@@ -11,7 +11,7 @@ public:
   static void kill(std::string jobs, std::string deployments);
   static void kill(std::string project_token, std::string jobs, std::string deployments);
   static void kill_message(json11::Json kill_json, std::string kill_type, std::string kill_details);
-  static void remote_add(std::string& project_name);
+  static void remote_add(std::string project_token);
  
 private:
   static bool exists(std::string directory);

--- a/src/usage.h
+++ b/src/usage.h
@@ -11,7 +11,7 @@ Usage:
     skafos logs [<project_token>] [-n <num>] [--tail]
     skafos fetch --table <table_name>
     skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
-    skafos remote info [<project_token>]
+    skafos remote info [<project_name>]
     skafos -h | --help
     skafos -v | --version
 Commands:

--- a/src/usage.h
+++ b/src/usage.h
@@ -11,7 +11,7 @@ Usage:
     skafos logs [<project_token>] [-n <num>] [--tail]
     skafos fetch --table <table_name>
     skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
-    skafos remote info [<project_name>]
+    skafos remote info [<project_token>]
     skafos -h | --help
     skafos -v | --version
 Commands:


### PR DESCRIPTION
Depending on the environment (production or staging), the base url for vasi remote info should change accordingly. The remote info command also uses the project name rather than the project_token.

## Changes 
- add the vasi base url for remote add to the env files 
- check if user inputed the project token first, otherwise set the project token based on current project. 
- use the vasi base url with respect to the environment