### PR TITLE
skafos whoami command

### DIFF
--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -30,6 +30,7 @@ void Auth::authenticate() {
   } else {
     string err;
 
+    Env::instance()->delete_defaults();
     Env::instance()->write_credentials(Json::parse(oauth.body, err));
     Env::instance()->load_credentials();
 

--- a/src/dispatch/dispatch.cpp
+++ b/src/dispatch/dispatch.cpp
@@ -58,8 +58,9 @@ struct command fetch_cmd              = {"fetch", {"--table"}, true, true};
 struct command kill_deployment_cmd    = {"kill", {"--deployments", "--job_ids"}, true, true};
 struct command remote_cmd             = {"remote", {}, true, true};
 struct command organizations_cmd      = {"orgs", {"--set-default"}, true, true};
+struct command whoami_cmd             = {"whoami", {}, false, true};
 
-struct command command_list[11]  = {
+struct command command_list[12]  = {
   setup_cmd, 
   init_cmd, 
   auth_cmd, 
@@ -70,7 +71,8 @@ struct command command_list[11]  = {
   fetch_cmd,
   kill_deployment_cmd,
   remote_cmd,
-  organizations_cmd
+  organizations_cmd,
+  whoami_cmd
 };
 
 

--- a/src/dispatch/dispatch.cpp
+++ b/src/dispatch/dispatch.cpp
@@ -19,6 +19,7 @@
 #include "project_env/project_env.h"
 #include "data/data.h"
 #include "organization/organization.h"
+#include "whoami/whoami.h"
 
 using namespace std;
 
@@ -376,10 +377,13 @@ void organizations(int argc, char **argv, int cmd_index) {
       console::error("You must supply an organization name and the --set-default argument to switch default organizations.");
       break;
     case 2:
-      console::info("All your organizations:\n");
       Organization::list();
       break;
   }
+}
+
+void whoami() {
+  Whoami::information();
 }
 
 

--- a/src/dispatch/dispatch.cpp
+++ b/src/dispatch/dispatch.cpp
@@ -397,6 +397,7 @@ int Dispatch::dispatch(int argc, char **argv, int cmd_index) {
   disp.insert("kill",          kill_deployment);
   disp.insert("remote",        remote);
   disp.insert("orgs",          organizations);
+  disp.insert("whoami",        whoami);
 
   if(command_list[cmd_index].needs_auth) {
     VERIFY_AUTH();

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -121,6 +121,12 @@ void Env::write_default_org(std::string org_name) {
   FileManager::write(paths.defaults, str);
 }
 
+void Env::delete_defaults() {
+  if(FileManager::file_exists(paths.defaults)){
+    FileManager::delete_file(paths.defaults);
+  }
+}
+
 void Env::verify_auth() {
   if(Env::instance()->authenticated() == false) {
     Auth::authenticate(); 

--- a/src/env/env.h
+++ b/src/env/env.h
@@ -41,6 +41,7 @@ public:
   bool load_defaults();
   void write_credentials(json11::Json object);
   void write_default_org(std::string org_name);
+  void delete_defaults();
   void verify_auth();
 
 private:

--- a/src/organization/organization.cpp
+++ b/src/organization/organization.cpp
@@ -11,7 +11,7 @@ void Organization::list() {
   if (error_message.size() > 0) {
     console::error("There was an error listing your organizations: " + error_message + "\n");
   } else if (json.is_array()) {
-    console::info("Your organizations:\n");
+    console::info("Your organizations: ");
     auto orgs = json.array_items();
     for (int i = 0; i < orgs.size(); i++) {
       console::info("   " + orgs[i]["display_name"].string_value());

--- a/src/organization/organization.cpp
+++ b/src/organization/organization.cpp
@@ -25,7 +25,7 @@ void Organization::set_default(std::string org_name) {
   std::string error_message = json["error"].string_value();
 
   if (error_message.size() > 0) {
-    console::error("There was an error listing your organizations: " + error_message + "\n");
+    console::error("There was an error setting your default organization: " + error_message + "\n");
   } else {
     Env::instance()->write_default_org(org_name);
     console::info(org_name + " is now your default organization");

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -21,6 +21,7 @@ const string KILL_DEPLOYMENT_URL   = "/kill";
 const string DEPLOYMENTS_URL       = "/deployments";
 const string OLD_ORGANIZATIONS_URL = "/old/organizations";
 const string ORGANIZATIONS_URL     = "/organizations";
+const string ME_URL                = "/users/me";
 
 #define DEFAULT_HEADERS() \
 RestClient::HeaderFields headers = this->_default_headers(); \
@@ -341,6 +342,12 @@ RestClient::Response Request::_org_by_name(std::string name) {
   return this->connection->get(uri);
 }
 
+RestClient::Response Request::_whoami() {
+  API_HEADERS();
+
+  return this->connection->get(ME_URL);
+}
+
 // DOWNLOAD
 size_t write_data(void *ptr, size_t size, size_t nmemb, FILE *stream)
 {
@@ -470,6 +477,10 @@ RestClient::Response Request::my_organizations() {
 
 RestClient::Response Request::org_by_name(std::string name) {
   return instance()->_org_by_name(name);
+}
+
+RestClient::Response Request::whoami() {
+  return instance()->_whoami();
 }
 
 // DOWNLOAD

--- a/src/request/request.h
+++ b/src/request/request.h
@@ -30,6 +30,7 @@ public:
   static RestClient::Response organization_info();
   static RestClient::Response my_organizations();
   static RestClient::Response org_by_name(std::string name);
+  static RestClient::Response whoami();
 
   static void download(std::string url, std::string save_path);
   static std::vector<std::string> string_split(const std::string& s, char delimiter);
@@ -67,6 +68,7 @@ private:
   RestClient::Response _organization_info();
   RestClient::Response _my_organizations();
   RestClient::Response _org_by_name(std::string name);
+  RestClient::Response _whoami();
 
   static void _download(std::string url, std::string save_path);
 };

--- a/src/usage.h
+++ b/src/usage.h
@@ -14,6 +14,7 @@ Usage:
     skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
     skafos remote info [<project_token>]
     skafos orgs [<name>] [--set-default]
+    skafos whoami
     skafos -h | --help
     skafos -v | --version
 Commands:
@@ -28,6 +29,7 @@ Commands:
     kill          Kill an entire project or specific jobs/deployments.
     remote info   Print command to add a new remote. 
     orgs          List or set your default organization.
+    whoami        List your current user info and settings.
 Options:
     -v --version    Shows version.
 

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef __CLI_VERSION__
 #define __CLI_VERSION__
 
-#define VERSION "1.5.6-dev"
+#define VERSION "1.6.0-dev"
 
 #endif
 

--- a/src/whoami/whoami.cpp
+++ b/src/whoami/whoami.cpp
@@ -1,0 +1,30 @@
+#include "env/env.h"
+#include "whoami.h"
+#include "organization/organization.h"
+
+using namespace json11;
+
+void Whoami::information() {
+  Env::instance()->load_defaults();
+  std::string default_org_name = Env::instance()->get(METIS_DEFAULT_ORG);
+
+  std::string err;
+  Json json = Json::parse(Request::whoami().body, err);
+  std::string error_message = json["error"].string_value();
+
+  if (error_message.size() > 0) {
+    console::error("There was an error listing your user information. \n");
+  } else {
+    console::info("Current Skafos user: ");
+    console::info("   " + json["email"].string_value() + "\n");
+
+    console::info("Default organization: ");
+    if (default_org_name.size() == 0) {
+      console::info("   You don't have a default organization set. \n     You can set one using the skafos orgs command. \n");
+    } else {
+      console::info("   " + default_org_name + "\n");
+    }
+
+    Organization::list();
+    }
+}

--- a/src/whoami/whoami.h
+++ b/src/whoami/whoami.h
@@ -1,0 +1,11 @@
+#ifndef __CLI__WHOAMI_H__
+#define __CLI__WHOAMI_H__
+
+#include "common.h"
+
+class Whoami {
+  public:
+    static void information();
+};
+
+#endif 


### PR DESCRIPTION
Allow users to list current skafos user information: who they are logged in as, their default organization, and their organizations they are a member of

## Changes 
- add whoami command to usage with description 
- add whoami command struct to command_list  
- add whoami to dispatch 
- whoami information command list `current_user`, `default_org`, and `organizations`
- add request to `/users/me` for whoami `current_user`
- added quick bug fix: delete defaults on `skafos auth` (better bug fix on the way)