### PR TITLE
default org bug - load default org on skafos auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,23 +38,31 @@ You can install [https://brew.sh/](Homebrew), or use the same process as Linux.
 
 ## Usage:
     skafos (setup|init|auth)...
-    skafos init [<name>] [--template <template_name>] [--master]
+    skafos init [<name>] [--org <org_name>] [--template <template_name>] [--master]
     skafos templates [--update] [--search <search_term>]
     skafos env [<key>] [--set <value>] [--delete]
+    skafos create [<kind>] [<name>] [--project <token>]
     skafos logs [<project_token>] [-n <num>] [--tail]
     skafos fetch --table <table_name>
     skafos kill [<project_token>] [--deployments <deployment_ids>] [--job_ids <job_ids>]
+    skafos remote info [<project_token>]
+    skafos orgs [<name>] [--set-default]
+    skafos whoami
     skafos -h | --help
     skafos -v | --version
 ## Commands:
-    setup       Setup development environment.
-    init        Create a new project.
-    auth        Authenticate request.
-    templates   Manage templates.
-    env         Get or set environment variables.
-    logs        Get logs for a project.
-    fetch       Fetch results from a given table.
-    kill        Kill an entire project or specific jobs/deployments.
+    setup         Setup development environment.
+    init          Create a new project.
+    auth          Authenticate request.
+    templates     Manage templates.
+    create        Create a Job for a project.
+    env           Get or set environment variables.
+    logs          Get logs for a project.
+    fetch         Fetch results from a given table.
+    kill          Kill an entire project or specific jobs/deployments.
+    remote info   Print command to add a new remote. 
+    orgs          List or set your default organization.
+    whoami        List your current user info and settings.
 ## Options:
     -V --version             Shows version.
 

--- a/build_envs/staging_env.h
+++ b/build_envs/staging_env.h
@@ -6,7 +6,7 @@
 
 const std::string ENVIRONMENT = "staging";
 const std::string CLIENT_ID   = "f1f6e59f3f6f8ffecde29d34ad18f673";
-const std::string API_URL     = "https://api.metis.wtf/v1";
+const std::string API_URL     = "http://localhost:4000/v1";
 const std::string LOGGING_URL = "https://api.metis.wtf/logs/";
 const std::string VASI_URL    = "https://vasi.metis.wtf/";
 

--- a/build_envs/staging_env.h
+++ b/build_envs/staging_env.h
@@ -6,7 +6,7 @@
 
 const std::string ENVIRONMENT = "staging";
 const std::string CLIENT_ID   = "f1f6e59f3f6f8ffecde29d34ad18f673";
-const std::string API_URL     = "http://localhost:4000/v1";
+const std::string API_URL     = "https://api.metis.wtf/v1";
 const std::string LOGGING_URL = "https://api.metis.wtf/logs/";
 const std::string VASI_URL    = "https://vasi.metis.wtf/";
 

--- a/src/auth/auth.cpp
+++ b/src/auth/auth.cpp
@@ -46,6 +46,14 @@ void Auth::authenticate() {
 
     console::debug("Loading credentials...");
     Env::instance()->load_credentials();
+
+    console::info("Loading defaults...");
+    
+    auto default_org = Json::parse(Request::my_default_org().body, err);
+
+    Env::instance()->write_default_org(default_org["display_name"].string_value());
+
+    Env::instance()->load_defaults();
   }
 }
 

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -38,7 +38,9 @@ void Env::setup() {
 }
 
 bool Env::authenticated() {
-  return (FileManager::file_exists(paths.credentials) && (Request::ping().body == "pong"));
+  Env::instance()->load_defaults();
+  string default_org_name = Env::instance()->get(METIS_DEFAULT_ORG);
+  return (FileManager::file_exists(paths.credentials) && (Request::ping().body == "pong") && (Request::org_by_name(default_org_name).code == 200));
 }
 
 string Env::get(string key) {

--- a/src/organization/organization.cpp
+++ b/src/organization/organization.cpp
@@ -25,12 +25,15 @@ void Organization::list() {
 }
 
 void Organization::set_default(std::string org_name) {
+  RestClient::Response resp = Request::set_default_org(org_name);
   std::string err;
-  Json json = Json::parse(Request::org_by_name(org_name).body, err);
-  std::string error_message = json["error"].string_value();
+  Json json = Json::parse(resp.body, err);
 
-  if (error_message.size() > 0) {
-    console::error("There was an error setting your default organization: " + error_message + "\n");
+  int status_code = resp.code;
+  std::string error_message = json["message"].string_value();
+
+  if (status_code != 201) {
+    console::error("There was an error setting your default organization: " + std::to_string(status_code) + " - " + error_message + "\n");
   } else {
     Env::instance()->write_default_org(org_name);
     console::info(org_name + " is now your default organization");

--- a/src/organization/organization.cpp
+++ b/src/organization/organization.cpp
@@ -4,18 +4,23 @@
 using namespace json11;
 
 void Organization::list() {
+  RestClient::Response resp = Request::my_organizations();
   std::string err;
-  Json json = Json::parse(Request::my_organizations().body, err);
-  std::string error_message = json["error"].string_value();
+  Json json = Json::parse(resp.body, err);
 
-  if (error_message.size() > 0) {
-    console::error("There was an error listing your organizations: " + error_message + "\n");
+  int status_code = resp.code;
+  std::string error_message = json["message"].string_value();
+
+  if (status_code != 200) {
+    console::error("There was an error listing your organizations: " + std::to_string(status_code) + " - " + error_message + "\n");
   } else if (json.is_array()) {
     console::info("Your organizations: ");
     auto orgs = json.array_items();
     for (int i = 0; i < orgs.size(); i++) {
       console::info("   " + orgs[i]["display_name"].string_value());
     }
+  } else {
+    console::error("There was an error listing your organizations \n");
   }
 }
 

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -22,6 +22,7 @@ const string DEPLOYMENTS_URL       = "/deployments";
 const string OLD_ORGANIZATIONS_URL = "/old/organizations";
 const string ORGANIZATIONS_URL     = "/organizations";
 const string ME_URL                = "/users/me";
+const string DEFAULT_ORG_URL       = "/organizations/default";
 
 #define DEFAULT_HEADERS() \
 RestClient::HeaderFields headers = this->_default_headers(); \

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -343,6 +343,16 @@ RestClient::Response Request::_org_by_name(std::string name) {
   return this->connection->get(uri);
 }
 
+RestClient::Response Request::_set_default_org(std::string name) {
+  API_HEADERS();
+
+  Json body = Json::object{
+    {"default_org", name}
+  };
+
+  return this->connection->post(DEFAULT_ORG_URL, body.dump());
+}
+
 RestClient::Response Request::_whoami() {
   API_HEADERS();
 

--- a/src/request/request.cpp
+++ b/src/request/request.cpp
@@ -353,6 +353,12 @@ RestClient::Response Request::_set_default_org(std::string name) {
   return this->connection->post(DEFAULT_ORG_URL, body.dump());
 }
 
+RestClient::Response Request::_my_default_org() {
+  API_HEADERS();
+
+  return this->connection->get(DEFAULT_ORG_URL);
+}
+
 RestClient::Response Request::_whoami() {
   API_HEADERS();
 
@@ -488,6 +494,14 @@ RestClient::Response Request::my_organizations() {
 
 RestClient::Response Request::org_by_name(std::string name) {
   return instance()->_org_by_name(name);
+}
+
+RestClient::Response Request::set_default_org(std::string name) {
+  return instance()->_set_default_org(name);
+}
+
+RestClient::Response Request::my_default_org() {
+  return instance()->_my_default_org();
 }
 
 RestClient::Response Request::whoami() {

--- a/src/request/request.h
+++ b/src/request/request.h
@@ -30,6 +30,8 @@ public:
   static RestClient::Response organization_info();
   static RestClient::Response my_organizations();
   static RestClient::Response org_by_name(std::string name);
+  static RestClient::Response set_default_org(std::string name);
+  static RestClient::Response my_default_org();
   static RestClient::Response whoami();
 
   static void download(std::string url, std::string save_path);
@@ -68,6 +70,8 @@ private:
   RestClient::Response _organization_info();
   RestClient::Response _my_organizations();
   RestClient::Response _org_by_name(std::string name);
+  RestClient::Response _set_default_org(std::string name);
+  RestClient::Response _my_default_org();
   RestClient::Response _whoami();
 
   static void _download(std::string url, std::string save_path);

--- a/src/version.h
+++ b/src/version.h
@@ -1,7 +1,7 @@
 #ifndef __CLI_VERSION__
 #define __CLI_VERSION__
 
-#define VERSION "1.7.0"
+#define VERSION "1.7.1-dev"
 
 #endif
 


### PR DESCRIPTION
:warning: :warning: :warning: Requires PRs: https://github.com/MetisMachine/argus/pull/311 https://github.com/MetisMachine/apoth/pull/118 :warning: :warning: :warning:

`skafos auth` command does not reset default organization

## Changes
- Upon `skafos auth`, get the user's default organization, write it to the `defaults.json` file, and load the default organization into the environment
- Add Requests to get and set the `default_organization`
- If the defaults.json file has been edited to an invalid or unauthorized org, require reauth
- Refactored error handling for listing organizations and setting the default organization
- Upon `skafos init`, do not create the files with empty tokens and ids in metis config file
