### PR TITLE
check if defaults.json exists on auth and check for success status codes

### DIFF
--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -40,7 +40,6 @@ void Env::setup() {
 bool Env::authenticated() {
   if (Env::instance()->load_defaults()){
     string default_org_name = Env::instance()->get(METIS_DEFAULT_ORG);
-    cout << Request::org_by_name(default_org_name).body;
     return (FileManager::file_exists(paths.credentials) && (Request::ping().body == "pong") && (std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), Request::org_by_name(default_org_name).code) != SUCCESS_CODES.end()));
   }
   return false;

--- a/src/env/env.cpp
+++ b/src/env/env.cpp
@@ -38,9 +38,12 @@ void Env::setup() {
 }
 
 bool Env::authenticated() {
-  Env::instance()->load_defaults();
-  string default_org_name = Env::instance()->get(METIS_DEFAULT_ORG);
-  return (FileManager::file_exists(paths.credentials) && (Request::ping().body == "pong") && (Request::org_by_name(default_org_name).code == 200));
+  if (Env::instance()->load_defaults()){
+    string default_org_name = Env::instance()->get(METIS_DEFAULT_ORG);
+    cout << Request::org_by_name(default_org_name).body;
+    return (FileManager::file_exists(paths.credentials) && (Request::ping().body == "pong") && (std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), Request::org_by_name(default_org_name).code) != SUCCESS_CODES.end()));
+  }
+  return false;
 }
 
 string Env::get(string key) {
@@ -95,6 +98,10 @@ bool Env::load_defaults() {
     }
 
     string org_name = json["org_name"].string_value();
+    if (org_name.length() < 1){
+      console::error("Defaults error: no default organization found.");
+      return false;
+    }
     this->set(METIS_DEFAULT_ORG, org_name);
     return true;
   }

--- a/src/env/env.h
+++ b/src/env/env.h
@@ -10,6 +10,7 @@
 #define VERIFY_AUTH Env::instance()->verify_auth
 #define ENV_PATHS Env::instance()->paths
 
+const std::list<int> SUCCESS_CODES    = {200, 201, 202, 203, 204};
 const std::string METIS_API_TOKEN     = "METIS_API_TOKEN";
 const std::string METIS_AUTH_TOKEN    = "METIS_OAUTH";
 const std::string METIS_DEFAULT_ORG   = "METIS_DEFAULT_ORG";

--- a/src/organization/organization.cpp
+++ b/src/organization/organization.cpp
@@ -1,5 +1,6 @@
 #include "file/file.h"
 #include "organization.h"
+#include "env/env.h"
 
 using namespace json11;
 
@@ -11,7 +12,7 @@ void Organization::list() {
   int status_code = resp.code;
   std::string error_message = json["message"].string_value();
 
-  if (status_code != 200) {
+  if (not(std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), status_code) != SUCCESS_CODES.end())) {
     console::error("There was an error listing your organizations: " + std::to_string(status_code) + " - " + error_message + "\n");
   } else if (json.is_array()) {
     console::info("Your organizations: ");
@@ -32,7 +33,7 @@ void Organization::set_default(std::string org_name) {
   int status_code = resp.code;
   std::string error_message = json["message"].string_value();
 
-  if (status_code != 201) {
+  if (not(std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), status_code) != SUCCESS_CODES.end())) {
     console::error("There was an error setting your default organization: " + std::to_string(status_code) + " - " + error_message + "\n");
   } else {
     Env::instance()->write_default_org(org_name);

--- a/src/project/project.cpp
+++ b/src/project/project.cpp
@@ -87,7 +87,7 @@ void Project::template_init(string name, string org_name, string tpl, bool maste
   status_code = resp.code;
   error_message = json["message"].string_value();
 
-  if(status_code != 201) {
+  if(not(std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), status_code) != SUCCESS_CODES.end())) {
     if (org_name.size() == 0) {
       console::error("Unable to create your project: " + std::to_string(status_code) + " - " + error_message + "\n");
     } else {
@@ -173,7 +173,7 @@ void Project::existing_init(string name, string org_name, bool master) {
   status_code = resp.code;
   error_message = json["message"].string_value();
 
-  if(status_code != 201) {
+  if(not(std::find(SUCCESS_CODES.begin(), SUCCESS_CODES.end(), status_code) != SUCCESS_CODES.end())) {
     if (org_name.size() == 0) {
       console::error("Unable to create your project: " + std::to_string(status_code) + " - " + error_message + "\n");
     } else {


### PR DESCRIPTION
:warning: needs https://github.com/MetisMachine/argus/pull/318 :warning:

- When checking for API request errors, check that the status code does not exist in the list of success codes 
- When loading defaults, check that the org_name exists in the file (i.e. is not `""`)
- When checking authentication, check that the defaults were able to be loaded then check token and access to org name 
  - Not authenticated if
    - `defaults.json` file does not exist
    - `defaults.json` does exist but `org_name` is empty 
    - user does not have access to organization listed in `defaults.json` file 
   -  api-token is invalid
   -  credentials do not exist